### PR TITLE
Can't access network release #34

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -153,6 +153,8 @@
         <entry key="../../../../layout/compose-model-1646221295818.xml" value="0.1" />
         <entry key="../../../../layout/compose-model-1646221307734.xml" value="0.3515151515151515" />
         <entry key="../../../../layout/compose-model-1646231087110.xml" value="0.3515151515151515" />
+        <entry key="../../../../layout/compose-model-1648166902140.xml" value="0.1" />
+        <entry key="../../../../layout/compose-model-1648167063677.xml" value="0.1" />
         <entry key="app/src/main/res/drawable-v24/ic_launcher_foreground.xml" value="0.1085" />
         <entry key="app/src/main/res/drawable/ic_inked_title.xml" value="0.1085" />
         <entry key="app/src/main/res/drawable/ic_launcher_background.xml" value="0.1085" />

--- a/README.md
+++ b/README.md
@@ -34,5 +34,5 @@ IDE : Android Studio Bumblebee | 2021.1.1 Patch 2
 Kotlin : 1.6.10  
 Gradle : 7.0.2  
 Java : 11  
-minSdk : 21  
+minSdk : 23  
 targetSdk : 31  

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,7 +11,7 @@ android {
     compileSdkVersion 31
     defaultConfig {
         applicationId 'com.io.github.rio_sh.quickwordbook'
-        minSdkVersion 21
+        minSdkVersion 23
         targetSdkVersion 31
         versionCode 1
         versionName '1.0'
@@ -20,7 +20,16 @@ android {
         buildConfigField 'String', 'API_URL', '"https://script.google.com/macros/s/AKfycbysAZbFYMW-fF4KWVMOcSLIjSKJTOvg_hHVKhVjie711rwpA8tr92cjSMASqw4N2cuVQw/"'
     }
 
+    Properties properties = new Properties()
+    properties.load(project.rootProject.file("local.properties").newDataInputStream())
+
     signingConfigs {
+        release {
+            storeFile file('/Users/ryo/AndroidStudioProjects/androidApkKey')
+            storePassword  properties.getProperty("RELEASE_STORE_PASSWORD")
+            keyAlias properties.getProperty("RELEASE_KEY_ALIAS")
+            keyPassword properties.getProperty("RELEASE_KEY_PASSWORD")
+        }
     }
 
     buildTypes {
@@ -32,6 +41,8 @@ android {
         release {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            signingConfig signingConfigs.release
+            buildConfigField 'String', 'API_URL', '"https://script.google.com/macros/s/AKfycbysAZbFYMW-fF4KWVMOcSLIjSKJTOvg_hHVKhVjie711rwpA8tr92cjSMASqw4N2cuVQw/"'
         }
     }
 

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,83 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+
+# Retrofit does reflection on generic parameters. InnerClasses is required to use Signature and
+# EnclosingMethod is required to use InnerClasses.
+-keepattributes Signature, InnerClasses, EnclosingMethod
+
+# Retrofit does reflection on method and parameter annotations.
+-keepattributes RuntimeVisibleAnnotations, RuntimeVisibleParameterAnnotations
+
+# Keep annotation default values (e.g., retrofit2.http.Field.encoded).
+-keepattributes AnnotationDefault
+
+# Retain service method parameters when optimizing.
+-keepclassmembers,allowshrinking,allowobfuscation interface * {
+    @retrofit2.http.* <methods>;
+}
+
+# Ignore annotation used for build tooling.
+-dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
+
+# Ignore JSR 305 annotations for embedding nullability information.
+-dontwarn javax.annotation.**
+
+# Guarded by a NoClassDefFoundError try/catch and only used when on the classpath.
+-dontwarn kotlin.Unit
+
+# Top-level functions that can only be used by Kotlin.
+-dontwarn retrofit2.KotlinExtensions
+#-dontwarn retrofit2.KotlinExtensions$*
+
+# With R8 full mode, it sees no subtypes of Retrofit interfaces since they are created with a Proxy
+# and replaces all potential values with null. Explicitly keeping the interfaces prevents this.
+-if interface * { @retrofit2.http.* <methods>; }
+-keep,allowobfuscation interface <1>
+
+# Keep generic signature of Call, Response (R8 full mode strips signatures from non-kept items).
+-keep,allowobfuscation,allowshrinking interface retrofit2.Call
+-keep,allowobfuscation,allowshrinking class retrofit2.Response
+
+# With R8 full mode generic signatures are stripped for classes that are not
+# kept. Suspend functions are wrapped in continuations where the type argument
+# is used.
+-keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation
+
+
+##---------------Begin: proguard configuration for Gson  ----------
+# Gson uses generic type information stored in a class file when working with fields. Proguard
+# removes such information by default, so configure it to keep all of it.
+-keepattributes Signature
+
+# For using GSON @Expose annotation
+-keepattributes *Annotation*
+
+# Gson specific classes
+-dontwarn sun.misc.**
+#-keep class com.google.gson.stream.** { *; }
+
+# Application classes that will be serialized/deserialized over Gson
+-keep class com.google.gson.examples.android.model.** { <fields>; }
+
+# Prevent proguard from stripping interface information from TypeAdapter, TypeAdapterFactory,
+# JsonSerializer, JsonDeserializer instances (so they can be used in @JsonAdapter)
+-keep class * extends com.google.gson.TypeAdapter
+-keep class * implements com.google.gson.TypeAdapterFactory
+-keep class * implements com.google.gson.JsonSerializer
+-keep class * implements com.google.gson.JsonDeserializer
+
+# Prevent R8 from leaving Data object members always null
+-keepclassmembers,allowobfuscation class * {
+  @com.google.gson.annotations.SerializedName <fields>;
+}
+
+# Retain generic signatures of TypeToken and its subclasses with R8 version 3.0 and higher.
+-keep,allowobfuscation,allowshrinking class com.google.gson.reflect.TypeToken
+-keep,allowobfuscation,allowshrinking class * extends com.google.gson.reflect.TypeToken
+
+##---------------End: proguard configuration for Gson  ----------
+
+# Avoid
+-keepnames class com.io.github.rio_sh.quickwordbook.network.** { *; }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
         android:name=".QuickWordbookApplication"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
+        android:usesCleartextTraffic="true"
         android:theme="@style/Theme.QuickWordbook">
         <activity
             android:name=".ui.QuickWordbookActivity"

--- a/app/src/main/java/com/io/github/rio_sh/quickwordbook/data/DefaultRepository.kt
+++ b/app/src/main/java/com/io/github/rio_sh/quickwordbook/data/DefaultRepository.kt
@@ -3,12 +3,10 @@ package com.io.github.rio_sh.quickwordbook.data
 import com.io.github.rio_sh.quickwordbook.network.GasService
 import com.io.github.rio_sh.quickwordbook.network.Languages
 import com.io.github.rio_sh.quickwordbook.network.ResponseText
-import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 import retrofit2.Response
-import java.lang.Exception
 import javax.inject.Inject
 
 // LocalDatasource's methods is assigned IO dispatcher at definition.


### PR DESCRIPTION
- upgrade minSdk to 23 for setting clearTextTraffic.
- setting proguard for avoid retrofit package obfuscated.

close #34 